### PR TITLE
Abstract authentication flow into new interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Added
-- The `get_server_info` method is now available in SDK. It is only supported against Conjur enterprise server 
 ### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
+- Abstract authentication flow into new `AuthenticationStrategyInterface`
+  [conjur-api-python#20](https://github.com/cyberark/conjur-api-python/pull/20)
+
+## [8.0.0] - 2022-05-25
+
+[Unreleased]: https://github.com/cyberark/conjur-api-python/compare/v8.0.0...HEAD
+[8.0.0]: https://github.com/cyberark/conjur-api-python/releases/tag/v8.0.0

--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ python API!
 The SDK can be installed via PyPI. Note that the SDK is a **Community level** project meaning that the SDK is subject to
 alterations that may result in breaking change.
 
-```
+```sh
+
 pip3 install conjur
+
 ```
 
 To avoid unanticipated breaking changes, make sure that you stay up-to-date on our latest releases and review the
@@ -48,8 +50,10 @@ source and not necessarily an official release.
 
 If you wish to install the library from the source clone the [project](https://github.com/cyberark/conjur-api-python) and run:
 
-```
+```sh
+
 pip3 install .
+
 ```
 
 ### Configuring the client
@@ -58,7 +62,7 @@ pip3 install .
 
 In order to login to conjur you need to have 5 parameters known from advance.
 
-```
+```python
 conjur_url = "https://my_conjur.com"
 account = "my_account"
 username = "user1"
@@ -70,7 +74,9 @@ ssl_verification_mode = SslVerificationMode.TRUST_STORE
 
 ConjurConnectionInfo is a data class containing all the non-credentials connection details.
 
-`connection_info = ConjurConnectionInfo(conjur_url=conjur_url,account=account,cert_file = None)`
+```python
+connection_info = ConjurConnectionInfo(conjur_url=conjur_url,account=account,cert_file=None)
+```
 
 * conjur_url - url of conjur server
 * account - the account which we want to connect to
@@ -88,23 +94,32 @@ fit (`keyring` usage for example)
 We also provide the user with a simple implementation of such provider called `SimpleCredentialsProvider`. Example of
 creating such provider + storing credentials:
 
-```
+```python
 credentials = CredentialsData(username=username, password=password, machine=conjur_url)
-
 credentials_provider = SimpleCredentialsProvider()
-
 credentials_provider.save(credentials)
-
 del credentials
+```
+
+#### Create authentication strategy
+
+The client also uses an authentication strategy in order to authenticate to conjur. This approach allows us to implement different authentication strategies
+(e.g. `authn`, `authn-ldap`, `authn-k8s`) and to keep the authentication logic separate from the client implementation.
+
+We provide the `AuthnAuthenticationStrategy` for the default Conjur authenticator. Example use:
+
+```python
+authn_provider = AuthnAuthenticationStrategy(credentials_provider)
 ```
 
 #### Creating the client and use it
 
-Now that we have created `connection_info` and `credentials_provider`
-We can create our client
+Now that we have created `connection_info` and `authn_provider`, we can create our client:
 
-```
-client = Client(connection_info, credentials_provider=credentials_provider, ssl_verification_mode=ssl_verification_mode)
+```python
+client = Client(connection_info,
+                authn_strategy=authn_provider,
+                ssl_verification_mode=ssl_verification_mode)
 ```
 
 * ssl_verification_mode = `SslVerificationMode` enum that states what is the certificate verification technique we will
@@ -112,10 +127,9 @@ client = Client(connection_info, credentials_provider=credentials_provider, ssl_
 
 After creating the client we can login to conjur and start using it. Example of usage:
 
-```
-client.login() # login to conjur and return the api_key`
-
-client.list() # get list of all conjur resources that the user authorize to read`
+```python
+client.login() # login to conjur and return the api_key
+client.list() # get list of all conjur resources that the user authorize to read
 ```
 
 ## Supported Client methods

--- a/conjur_api/__init__.py
+++ b/conjur_api/__init__.py
@@ -7,6 +7,7 @@ __version__ = "0.0.5"
 
 from conjur_api.client import Client
 from conjur_api.interface import CredentialsProviderInterface
+from conjur_api.interface import AuthenticationStrategyInterface
 from conjur_api import models
 from conjur_api import errors
 from conjur_api import providers

--- a/conjur_api/interface/__init__.py
+++ b/conjur_api/interface/__init__.py
@@ -4,3 +4,4 @@ Interface module
 This module holds all the exposed interfaces of the SDK
 """
 from conjur_api.interface.credentials_store_interface import CredentialsProviderInterface
+from conjur_api.interface.authentication_strategy_interface import AuthenticationStrategyInterface

--- a/conjur_api/interface/authentication_strategy_interface.py
+++ b/conjur_api/interface/authentication_strategy_interface.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+"""
+AuthenticationStrategy Interface
+This class describes a shared interface for authenticating to Conjur
+"""
+
+# Builtins
+import abc
+from conjur_api.models.general.conjur_connection_info import ConjurConnectionInfo
+from conjur_api.models.ssl.ssl_verification_metadata import SslVerificationMetadata
+
+# pylint: disable=too-few-public-methods
+class AuthenticationStrategyInterface(metaclass=abc.ABCMeta):  # pragma: no cover
+    """
+    AuthenticationStrategyInterface
+    This class is an interface that outlines a shared interface for authentication strategies
+    """
+
+    @abc.abstractmethod
+    async def authenticate(
+        self,
+        connection_info: ConjurConnectionInfo,
+        ssl_verification_data: SslVerificationMetadata
+    ) -> str:
+        """
+        Authenticate uses the api_key to fetch a short-lived conjur_api token that
+        for a limited time will allow you to interact fully with the Conjur
+        vault.
+        """

--- a/conjur_api/models/__init__.py
+++ b/conjur_api/models/__init__.py
@@ -13,3 +13,4 @@ from conjur_api.models.list.list_members_of_data import ListMembersOfData
 from conjur_api.models.hostfactory.create_host_data import CreateHostData
 from conjur_api.models.ssl.ssl_verification_mode import SslVerificationMode
 from conjur_api.models.general.credentials_data import CredentialsData
+from conjur_api.models.enums.authn_types import AuthnTypes

--- a/conjur_api/models/enums/authn_types.py
+++ b/conjur_api/models/enums/authn_types.py
@@ -1,0 +1,21 @@
+"""
+AuthnTypes module
+This module is used to represent different authentication methods.
+"""
+
+from enum import Enum
+
+
+class AuthnTypes(Enum):   # pragma: no cover
+    """
+    Represent possible authn methods that can be used.
+    """
+    AUTHN = 0
+    # Future:
+    # LDAP = 1
+
+    def __str__(self):
+        """
+        Return string representation of AuthnTypes.
+        """
+        return self.name.lower()

--- a/conjur_api/providers/__init__.py
+++ b/conjur_api/providers/__init__.py
@@ -4,3 +4,4 @@ Providers module
 This module holds all the providers of the SDK
 """
 from conjur_api.providers.simple_credentials_provider import SimpleCredentialsProvider
+from conjur_api.providers.authn_authentication_strategy import AuthnAuthenticationStrategy

--- a/conjur_api/providers/authn_authentication_strategy.py
+++ b/conjur_api/providers/authn_authentication_strategy.py
@@ -1,0 +1,90 @@
+"""
+AuthnAuthenticationStrategy module
+
+This module holds the AuthnAuthenticationStrategy class
+"""
+
+import logging
+from conjur_api.errors.errors import MissingRequiredParameterException
+from conjur_api.http.endpoints import ConjurEndpoint
+from conjur_api.interface.authentication_strategy_interface import AuthenticationStrategyInterface
+from conjur_api.interface.credentials_store_interface import CredentialsProviderInterface
+from conjur_api.models.general.conjur_connection_info import ConjurConnectionInfo
+from conjur_api.models.general.credentials_data import CredentialsData
+from conjur_api.models.ssl.ssl_verification_metadata import SslVerificationMetadata
+from conjur_api.wrappers.http_wrapper import HttpVerb, invoke_endpoint
+
+class AuthnAuthenticationStrategy(AuthenticationStrategyInterface):
+    """
+    AuthnAuthenticationStrategy class
+
+    This class implements the "authn" strategy of authentication, which is Conjur's default authenticator type
+    """
+    def __init__(
+            self,
+            credentials_provider: CredentialsProviderInterface,
+    ):
+        self._credentials_provider = credentials_provider
+        self._api_key = None
+
+    def _retrieve_credential_data(self, url: str) -> CredentialsData:
+        credential_location = self._credentials_provider.get_store_location()
+        logging.debug("Retrieving credentials from the '%s'...", credential_location)
+
+        return self._credentials_provider.load(url)
+
+    async def login(self, connection_info: ConjurConnectionInfo, ssl_verification_data: SslVerificationMetadata) -> str:
+        """
+        Login uses a username and password to fetch a long-lived conjur_api token
+        """
+
+        logging.debug("Logging in to %s...", connection_info.conjur_url)
+        url = connection_info.conjur_url
+        account = connection_info.conjur_account
+        creds = self._retrieve_credential_data(url)
+
+        if not creds.password:
+            raise MissingRequiredParameterException("password requires when login")
+
+        params = {
+            'url': url,
+            'account': account
+        }
+        response = await invoke_endpoint(HttpVerb.GET, ConjurEndpoint.LOGIN,
+                                         params, auth=(creds.username, creds.password),
+                                         ssl_verification_metadata=ssl_verification_data)
+        self._api_key = response.text
+        return self._api_key
+
+    async def authenticate(self, connection_info, ssl_verification_data) -> str:
+        """
+        Authenticate uses the api_key (retrieved in `login()`) to fetch a short-lived conjur_api token that
+        for a limited time will allow you to interact fully with the Conjur vault.
+        """
+        url = connection_info.conjur_url
+        account = connection_info.conjur_account
+        creds = self._retrieve_credential_data(url)
+
+        if not self._api_key and creds.username and creds.password:
+            # TODO we do this since api_key is not provided. it should be stored like username,
+            # password inside credentials_data
+            await self.login(connection_info, ssl_verification_data)
+
+        if not creds.username or not self._api_key:
+            raise MissingRequiredParameterException("Missing parameters in "
+                                                    "authentication invocation")
+
+        params = {
+            'url': url,
+            'account': account,
+            'login': creds.username
+        }
+
+        logging.debug("Authenticating to %s...", url)
+        response = await invoke_endpoint(
+            HttpVerb.POST,
+            ConjurEndpoint.AUTHENTICATE,
+            params,
+            self._api_key,
+            ssl_verification_metadata=ssl_verification_data)
+        return response.text

--- a/tests/authentication_strategy/test_unit_authn_authentication_provider.py
+++ b/tests/authentication_strategy/test_unit_authn_authentication_provider.py
@@ -1,0 +1,25 @@
+from aiounittest import AsyncTestCase
+
+from conjur_api.errors.errors import MissingRequiredParameterException
+from conjur_api.models.general.conjur_connection_info import ConjurConnectionInfo
+from conjur_api.models.general.credentials_data import CredentialsData
+from conjur_api.providers import AuthnAuthenticationStrategy
+from conjur_api.providers.simple_credentials_provider import SimpleCredentialsProvider
+
+class AuthnAuthenticationStrategyTest(AsyncTestCase):
+    
+    async def test_missing_username(self):
+        conjur_url = "https://conjur.example.com"
+        connection_info = ConjurConnectionInfo(conjur_url, "some_account")
+
+        credentials_provider = SimpleCredentialsProvider()
+        credentials = CredentialsData(password="mypassword",machine=conjur_url)
+        credentials_provider.save(credentials)
+        
+        provider = AuthnAuthenticationStrategy(
+            credentials_provider
+        )
+        with self.assertRaises(MissingRequiredParameterException) as context:
+            await provider.authenticate(connection_info, None)
+
+        self.assertRegex(context.exception.message, "Missing parameters")

--- a/tests/integration/test_integration_vanila.py
+++ b/tests/integration/test_integration_vanila.py
@@ -5,7 +5,7 @@ from aiounittest import AsyncTestCase
 
 from conjur_api import Client
 from conjur_api.models import  SslVerificationMode, ConjurConnectionInfo, CredentialsData
-from conjur_api.providers import SimpleCredentialsProvider
+from conjur_api.providers import AuthnAuthenticationStrategy, SimpleCredentialsProvider
 
 
 class TestIntegrationVanila(AsyncTestCase):
@@ -25,9 +25,10 @@ class TestIntegrationVanila(AsyncTestCase):
             account=account
         )
         credentials_provider = SimpleCredentialsProvider()
+        authn_provider = AuthnAuthenticationStrategy(credentials_provider)
         credentials = CredentialsData(username=username, password=api_key,machine=conjur_url)
         credentials_provider.save(credentials)
-        c = Client(conjur_data, credentials_provider=credentials_provider,
+        c = Client(conjur_data, authn_strategy=authn_provider,
                    ssl_verification_mode=SslVerificationMode.INSECURE)
         resources = await c.list()
         self.assertEqual(len(resources), 2)


### PR DESCRIPTION
Note: To see implementation in the CLI, see https://github.com/cyberark/cyberark-conjur-cli/pull/410

### Desired Outcome

Create a new `AuthenticationStrategy` interface that will allow us to abstract the authentication flow. The interface should
take a `CredentialProvider` and Conjur account as inputs, as well as any other arguments that are needed to authenticate,
such as `service_id` for LDAP. The interface should have a `authenticate` method which returns a Conjur auth token. All details of authentication should be handled by the `AuthenticationStrategy` interface.
Include unit tests and update existing unit and integration tests.

### Implemented Changes

- Added `AuthenticationStrategyInterface` to abstract authentication logic
- Added `AuthnAuthenticationStrategy` which implements the interface for the default authn strategy
- Updated the Api class to use the interface to implement authentication

### Connected Issue/Story

CyberArk internal issue link: [ONYX-20429](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-20429)

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
