### PR TITLE
Fix failing tests due to chromium/badssl.com#501

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Python cache files
+*.pyc
+__pycache__
+
+# Test artifacts
+.coverage
+coverage.xml
+ci/test/output/
+.env
+*.crt
+*.key

--- a/tests/https/test_unit_http_ssl.py
+++ b/tests/https/test_unit_http_ssl.py
@@ -45,9 +45,10 @@ valid_badssl_endpoints = [
     "https://rsa4096.badssl.com",
     "https://rsa8192.badssl.com",
     "https://sha256.badssl.com",
-    "https://sha384.badssl.com",
-    "https://sha512.badssl.com",
-    # "https://tls-v1-2.badssl.com",
+    # These are temporarily broken, see https://github.com/chromium/badssl.com/issues/501
+    # "https://sha384.badssl.com",
+    # "https://sha512.badssl.com",
+    "https://tls-v1-2.badssl.com",
     "https://cbc.badssl.com"
 ]
 


### PR DESCRIPTION
### Desired Outcome

Fix SSL tests failing with SSLCertVerificationError

### Implemented Changes

- Temporarily commented out tests for `sha384.badssl.com` and `sha512.badssl.com` since their certs have expired and are causing false negatives.
  See similar PR in AWS's s2n-tls: https://github.com/aws/s2n-tls/pull/3322
- Also added a basic .gitignore file to keep pycache and test artifacts out of the repo

### Connected Issue/Story

N/A

### Definition of Done

- [x] Unit tests pass

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
