### PR TITLE
Store api key in credential data object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [conjur-api-python#20](https://github.com/cyberark/conjur-api-python/pull/20)
 - Add support for LDAP authentication
   [conjur-api-python#22](https://github.com/cyberark/conjur-api-python/pull/22)
+- Store API key in `CreditentialsData` object
+  [conjur-api-python#23](https://github.com/cyberark/conjur-api-python/pull/23)
 
 
 [Unreleased]: https://github.com/cyberark/conjur-api-python/compare/v8.0.0...HEAD

--- a/conjur_api/models/general/credentials_data.py
+++ b/conjur_api/models/general/credentials_data.py
@@ -13,10 +13,11 @@ class CredentialsData:
     Used for setting user input data to login to Conjur
     """
 
-    def __init__(self, machine: str = None, username: str = None, password: str = None):
+    def __init__(self, machine: str = None, username: str = None, password: str = None, api_key: str = None):
         self.machine = machine
         self.username = username
         self.password = password
+        self.api_key = api_key
 
     @classmethod
     def convert_dict_to_obj(cls, dic: dict):
@@ -27,11 +28,11 @@ class CredentialsData:
 
     # pylint: disable=line-too-long
     def __repr__(self):
-        return f"{{'machine': '{self.machine}', 'username': '{self.username}', 'password': '****'}}"
+        return f"{{'machine': '{self.machine}', 'username': '{self.username}', 'password': '****', 'api_key': '****'}}"
 
     def __eq__(self, other) -> bool:
         """
         Method for comparing resources by their values and not by reference
         """
         return self.machine == other.machine and self.username == other.username and self.password == \
-               other.password
+               other.password and self.api_key == other.api_key

--- a/conjur_api/providers/ldap_authentication_strategy.py
+++ b/conjur_api/providers/ldap_authentication_strategy.py
@@ -50,7 +50,7 @@ class LdapAuthenticationStrategy(AuthnAuthenticationStrategy):
             HttpVerb.POST,
             ConjurEndpoint.AUTHENTICATE_LDAP,
             params,
-            self._api_key,
+            creds.api_key,
             ssl_verification_metadata=ssl_verification_data)
         return response.text
 

--- a/tests/credentials_provider/test_unit_simple_credentials_provider.py
+++ b/tests/credentials_provider/test_unit_simple_credentials_provider.py
@@ -4,8 +4,8 @@ from conjur_api.providers import SimpleCredentialsProvider
 from conjur_api.models import CredentialsData
 
 
-def create_credentials(machine: str = "machine", username: str = "some_username", password: str = "some_password"):
-    return CredentialsData(machine, username, password)
+def create_credentials(machine: str = "machine", username: str = "some_username", password: str = "some_password", api_key: str = "some_api_key") -> CredentialsData:
+    return CredentialsData(machine, username, password, api_key)
 
 
 class SimpleCredentialsProviderTest(TestCase):
@@ -22,7 +22,7 @@ class SimpleCredentialsProviderTest(TestCase):
         credentials_data1 = create_credentials()
         provider.save(credentials_data1)
 
-        credentials_data2 = create_credentials("machine2", "user2", "psswd2")
+        credentials_data2 = create_credentials("machine2", "user2", "psswd2", "api_key2")
         provider.save(credentials_data2)
 
         self.assertEqual(credentials_data1, provider.load(credentials_data1.machine))

--- a/tests/integration/test_integration_vanila.py
+++ b/tests/integration/test_integration_vanila.py
@@ -26,7 +26,7 @@ class TestIntegrationVanila(AsyncTestCase):
         )
         credentials_provider = SimpleCredentialsProvider()
         authn_provider = AuthnAuthenticationStrategy(credentials_provider)
-        credentials = CredentialsData(username=username, password=api_key, machine=conjur_url)
+        credentials = CredentialsData(username=username, api_key=api_key, machine=conjur_url)
         credentials_provider.save(credentials)
         c = Client(conjur_data, authn_strategy=authn_provider,
                    ssl_verification_mode=SslVerificationMode.INSECURE)


### PR DESCRIPTION
### Desired Outcome

Cache the API key in the `CredentialsData` object instead of in a variable in memory. This allows us to provide it from saved storage (either netrc file or keystore), and allows us to be explicit about whether we're using a user password or an actual API key, which currently are used somewhat interchangeably in the code.

### Implemented Changes

- Add an `api_key` field to `CredentialsData`
- Modify `AuthnAuthenticationStrategy` and `LdapAuthenticationStrategy` to store and retrieve the api token from the credentials provider instead of in an instance variable.

### Connected Issue/Story

Resolves N/A

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
