### PR TITLE
Downgrade ubuntu base images to 20.04 LTS

### DIFF
--- a/ci/publish/Dockerfile.publish
+++ b/ci/publish/Dockerfile.publish
@@ -1,4 +1,4 @@
-FROM ubuntu:21.10
+FROM ubuntu:20.04
 ENV INSTALL_DIR=/opt/conjur-api-python3
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \

--- a/ci/test/Dockerfile.test
+++ b/ci/test/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM ubuntu:21.10
+FROM ubuntu:20.04
 ENV INSTALL_DIR=/opt/conjur-api-python
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
### Desired Outcome

Fix broken CI due to Ubuntu 21.10 EOL

### Implemented Changes

- Changed Ubuntu base image in all Dockerfiles to use the 20.04 LTS version of Ubuntu

### Connected Issue/Story

N/A

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
