### PR TITLE
Added more tests for enabling and disabling authenticators

### DIFF
--- a/tests/https/test_unit_client.py
+++ b/tests/https/test_unit_client.py
@@ -274,7 +274,7 @@ class ClientTest(IsolatedAsyncioTestCase):
                    ssl_verification_mode=SslVerificationMode.INSECURE)
         response = await c.set_authenticator_state('authn-iam/test', True)
 
-        self.assertTrue(response == '')
+        self.assertEqual(response, '')
 
     @patch('aiohttp.ClientSession.request')
     async def test_client_disable_valid_authenticator(self, mock_request):
@@ -285,7 +285,7 @@ class ClientTest(IsolatedAsyncioTestCase):
                    ssl_verification_mode=SslVerificationMode.INSECURE)
         response = await c.set_authenticator_state('authn-iam/test', False)
 
-        self.assertTrue(response == '')
+        self.assertEqual(response, '')
 
     @patch('aiohttp.ClientSession.request')
     async def test_client_enable_authenticator_no_permissions(self, mock_request):
@@ -330,6 +330,28 @@ class ClientTest(IsolatedAsyncioTestCase):
 
         with self.assertRaises(HttpError) as context:
             await c.set_authenticator_state('authn-iam/test', False)
+
+    @patch('aiohttp.ClientSession.request')
+    async def test_client_enable_authenticator_without_service_id(self, mock_request):
+        conjur_data, credentials_provider = self._initialize_input()
+
+        mock_request.return_value = MockResponse('', 204)
+        c = Client(conjur_data, authn_strategy=AuthnAuthenticationStrategy(credentials_provider),
+                   ssl_verification_mode=SslVerificationMode.INSECURE)
+        response = await c.set_authenticator_state('authn-gcp', True)
+
+        self.assertEqual(response, '')
+
+    @patch('aiohttp.ClientSession.request')
+    async def test_client_disable_authenticator_without_service_id(self, mock_request):
+        conjur_data, credentials_provider = self._initialize_input()
+
+        mock_request.return_value = MockResponse('', 204)
+        c = Client(conjur_data, authn_strategy=AuthnAuthenticationStrategy(credentials_provider),
+                   ssl_verification_mode=SslVerificationMode.INSECURE)
+        response = await c.set_authenticator_state('authn-gcp', False)
+
+        self.assertEqual(response, '')
 
     @staticmethod
     def _initialize_input() -> tuple[ConjurConnectionInfo, SimpleCredentialsProvider]:

--- a/tests/integration/policies/authn-gcp.yml
+++ b/tests/integration/policies/authn-gcp.yml
@@ -1,0 +1,16 @@
+- !policy
+  id: authn-gcp
+  body:
+    - !webservice
+
+    - !group clients
+
+    - !permit
+      role: !group clients
+      privilege: [ read, authenticate ]
+      resource: !webservice
+
+    - !permit
+      role: !user /test-authenticator-valid-user
+      privilege: [ update ]
+      resource: !webservice

--- a/tests/integration/test_integration_authenticator_state.py
+++ b/tests/integration/test_integration_authenticator_state.py
@@ -31,6 +31,22 @@ class TestEnableDisableAuthenticators(AsyncTestCase):
 
         self.assertEqual(response, '')
 
+    async def test_authenticator_enable_twice_success(self):
+        c = await create_client(self.valid_user.id, self.valid_user.api_key)
+
+        response = await c.set_authenticator_state('authn-iam/test', True)
+        self.assertEqual(response, '')
+        response = await c.set_authenticator_state('authn-iam/test', True)
+        self.assertEqual(response, '')
+
+    async def test_authenticator_disable_twice_success(self):
+        c = await create_client(self.valid_user.id, self.valid_user.api_key)
+
+        response = await c.set_authenticator_state('authn-iam/test', False)
+        self.assertEqual(response, '')
+        response = await c.set_authenticator_state('authn-iam/test', False)
+        self.assertEqual(response, '')
+
     async def test_authenticator_enable_no_permissions(self):
         c = await create_client(self.invalid_user.id, self.invalid_user.api_key)
 
@@ -57,6 +73,30 @@ class TestEnableDisableAuthenticators(AsyncTestCase):
             response = await c.set_authenticator_state('authn-iam/non-existing', False)
         self.assertEqual(context.exception.status, 401)
 
+    async def test_authenticator_enable_without_service_id_success(self):
+        c = await create_client(self.valid_user.id, self.valid_user.api_key)
+        response = await c.set_authenticator_state('authn-gcp', True)
+
+        self.assertEqual(response, '')
+
+    async def test_authenticator_disable_without_service_id_success(self):
+        c = await create_client(self.valid_user.id, self.valid_user.api_key)
+        response = await c.set_authenticator_state('authn-gcp', False)
+
+        self.assertEqual(response, '')
+
+    async def test_authenticator_enable_without_service_id_failure(self):
+        c = await create_client(self.invalid_user.id, self.invalid_user.api_key)
+        with self.assertRaises(HttpStatusError) as context:
+            response = await c.set_authenticator_state('authn-gcp', True)
+        self.assertEqual(context.exception.status, 403)
+
+    async def test_authenticator_disable_without_service_id_failure(self):
+        c = await create_client(self.invalid_user.id, self.invalid_user.api_key)
+        with self.assertRaises(HttpStatusError) as context:
+            response = await c.set_authenticator_state('authn-gcp', False)
+        self.assertEqual(context.exception.status, 403)
+
     @classmethod
     async def _add_test_data(cls):
         c = await create_client("admin", os.environ['CONJUR_AUTHN_API_KEY'])
@@ -68,6 +108,7 @@ class TestEnableDisableAuthenticators(AsyncTestCase):
                                               api_key=response['created_roles']['dev:user:test-authenticator-invalid-user']
                                               ['api_key'])
         response = await c.load_policy_file('conjur', 'tests/integration/policies/authn-iam-test.yml')
+        response = await c.load_policy_file('conjur', 'tests/integration/policies/authn-gcp.yml')
 
         cls.valid_user = valid_user
         cls.invalid_user = invalid_user

--- a/tests/integration/test_integration_authenticator_state.py
+++ b/tests/integration/test_integration_authenticator_state.py
@@ -85,13 +85,13 @@ class TestEnableDisableAuthenticators(AsyncTestCase):
 
         self.assertEqual(response, '')
 
-    async def test_authenticator_enable_without_service_id_failure(self):
+    async def test_authenticator_enable_failure_while_auth_without_service_id(self):
         c = await create_client(self.invalid_user.id, self.invalid_user.api_key)
         with self.assertRaises(HttpStatusError) as context:
             response = await c.set_authenticator_state('authn-gcp', True)
         self.assertEqual(context.exception.status, 403)
 
-    async def test_authenticator_disable_without_service_id_failure(self):
+    async def test_authenticator_disable_failure_while_auth_without_service_id(self):
         c = await create_client(self.invalid_user.id, self.invalid_user.api_key)
         with self.assertRaises(HttpStatusError) as context:
             response = await c.set_authenticator_state('authn-gcp', False)


### PR DESCRIPTION
### Desired Outcome

Added more tests for the authenticators enabling and disabling feature.

### Implemented Changes

- Added tests for an authenticator that doesn't have a service ID
- Added tests for enabling and disabling twice
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

ONYX-23423

### Definition of Done

#### Changelog

- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or

#### Documentation

- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] No behavior was changed with this PR

#### Security

- [ ] There are no security aspects to these changes 
