### PR TITLE
Add support for Show Resource endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [8.0.0] - 2022-05-25
 
+### Added
+- Add support for Show Resource endpoint
+  [conjur-api-python#31](https://github.com/cyberark/conjur-api-python/pull/31)
+- Add support for LDAP authentication
+  [conjur-api-python#22](https://github.com/cyberark/conjur-api-python/pull/22)
+
 ### Changed
 - Abstract authentication flow into new `AuthenticationStrategyInterface`
   [conjur-api-python#20](https://github.com/cyberark/conjur-api-python/pull/20)
-- Add support for LDAP authentication
-  [conjur-api-python#22](https://github.com/cyberark/conjur-api-python/pull/22)
 - Store API key in `CreditentialsData` object
   [conjur-api-python#23](https://github.com/cyberark/conjur-api-python/pull/23)
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ For example: `client.list({'kind': 'user', 'inspect': True})`
 | search           | Search for resources based on specified query                |
 | inspect          | List the metadata for resources                              |
 
+#### `get_resource(kind, resource_id)`
+
+Gets a resource based on its kind and ID. Resource is json data that contains metadata about the resource.
+
 #### `def list_permitted_roles(list_permitted_roles_data: ListPermittedRolesData)`
 
 Lists the roles which have the named permission on a resource.

--- a/conjur_api/client.py
+++ b/conjur_api/client.py
@@ -105,6 +105,12 @@ class Client:
         """
         return await self._api.resources_list(list_constraints)
 
+    async def get_resource(self, kind: str, resource_id: str) -> json:
+        """
+        Gets a resource based on its kind and ID
+        """
+        return await self._api.get_resource(kind, resource_id)
+
     async def list_permitted_roles(self, list_permitted_roles_data: ListPermittedRolesData) -> dict:
         """
         Lists the roles which have the named permission on a resource.

--- a/conjur_api/http/api.py
+++ b/conjur_api/http/api.py
@@ -156,6 +156,29 @@ class Api:
         # ?tocpath=Developer%7CREST%C2%A0APIs%7C_____17
         return resources
 
+    async def get_resource(self, kind: str, resource_id: str) -> dict:
+        """
+        This method is used to fetch a specific resource.
+        """
+        params = {
+            'account': self._account,
+            'kind': kind,
+            'identifier': resource_id
+        }
+        params.update(self._default_params)
+
+        response = await invoke_endpoint(HttpVerb.GET, ConjurEndpoint.RESOURCE,
+                                         params,
+                                         api_token=await self.api_token,
+                                         ssl_verification_metadata=self.ssl_verification_data)
+
+        resource = response.json
+
+        # To see the full resources response see
+        # https://docs.conjur.org/Latest/en/Content/Developer/Conjur_API_Show_Resources.htm
+        # ?tocpath=Developer%7CREST%C2%A0APIs%7C_____19
+        return resource
+
     async def get_variable(self, variable_id: str, version: str = None) -> Optional[bytes]:
         """
         This method is used to fetch a secret's (aka "variable") value from

--- a/conjur_api/http/endpoints.py
+++ b/conjur_api/http/endpoints.py
@@ -25,6 +25,7 @@ class ConjurEndpoint(Enum):
     BATCH_SECRETS = "{url}/secrets"
     SECRETS = "{url}/secrets/{account}/{kind}/{identifier}"
     RESOURCES = "{url}/resources/{account}"
+    RESOURCE = "{url}/resources/{account}/{kind}/{identifier}"
     ROTATE_API_KEY = "{url}/authn/{account}/api_key"
     CHANGE_PASSWORD = "{url}/authn/{account}/password"
     WHOAMI = "{url}/whoami"

--- a/tests/https/test_unit_client.py
+++ b/tests/https/test_unit_client.py
@@ -227,6 +227,17 @@ class ClientTest(IsolatedAsyncioTestCase):
         mock_invoke_endpoint.assert_called_once()
 
     @patch.object(Api, '_api_token', new_callable=PropertyMock)  
+    async def test_client_get_resource_invokes_api(self, mock_api_token, mock_invoke_endpoint):
+        mock_api_token.return_value = 'test_token'
+        await self.client.get_resource('policy', 'dummy')
+
+        args, kwargs = mock_invoke_endpoint.call_args
+        self.assertEqual('test_token', kwargs.get('api_token'))
+        self.assertTrue(exists_in_args('policy', args))
+        self.assertTrue(exists_in_args('dummy', args))
+        mock_invoke_endpoint.assert_called_once()
+
+    @patch.object(Api, '_api_token', new_callable=PropertyMock)  
     async def test_client_get_many_invokes_api(self, mock_api_token, mock_invoke_endpoint):
         mock_api_token.return_value = 'test_token'
         json_data = '{"test:variable:dummy-var":"myValue", \

--- a/tests/https/test_unit_endpoints.py
+++ b/tests/https/test_unit_endpoints.py
@@ -41,6 +41,13 @@ class EndpointsTest(unittest.TestCase):
                                                              account='myacct')
         self.assertEqual(auth_endpoint, 'http://host/resources/myacct')
 
+    def test_endpoint_has_correct_resource_template_string(self):
+        endpoint = ConjurEndpoint.RESOURCE.value.format(url='http://host',
+                                                             account='myacct',
+                                                             kind='varkind',
+                                                             identifier='varid')
+        self.assertEqual(endpoint, 'http://host/resources/myacct/varkind/varid')
+
     def test_endpoint_has_correct_whoami_template_string(self):
         auth_endpoint = ConjurEndpoint.WHOAMI.value.format(url='http://host',
                                                              account='myacct')


### PR DESCRIPTION
### Desired Outcome

Add support for the [Show a Resource](https://docs.conjur.org/Latest/en/Content/Developer/Conjur_API_Show_Resources.htm?tocpath=Developer%7CREST%C2%A0APIs%7C_____19) REST API endpoint.

### Implemented Changes

Added a `get_resource` method to the `Client` and `Api` classes which invokes the `resources/{account}/{kind}/{identifier}` url on the Conjur server.

### Connected Issue/Story

Supports CyberArk internal issue: [ONYX-23088](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-23088)

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
