### PR TITLE
Add resource_exists method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [conjur-api-python#30](https://github.com/cyberark/conjur-api-python/pull/30)
 - Add support for Show Resource endpoint
   [conjur-api-python#31](https://github.com/cyberark/conjur-api-python/pull/31)
+- Add `resource_exists` method
+  [conjur-api-python#32](https://github.com/cyberark/conjur-api-python/pull/32)
 - Add support for LDAP authentication
   [conjur-api-python#22](https://github.com/cyberark/conjur-api-python/pull/22)
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,10 @@ For example: `client.list({'kind': 'user', 'inspect': True})`
 
 Gets a resource based on its kind and ID. Resource is json data that contains metadata about the resource.
 
+#### `resource_exists(kind, resource_id)`
+
+Check the existence of a resource based on its kind and ID. Returns a boolean.
+
 #### `get_role(kind, role_id)`
 
 Gets a role based on its kind and ID. Role is json data that contains metadata about the role.

--- a/conjur_api/client.py
+++ b/conjur_api/client.py
@@ -111,6 +111,12 @@ class Client:
         """
         return await self._api.get_resource(kind, resource_id)
 
+    async def resource_exists(self, kind: str, resource_id: str) -> bool:
+        """
+        Check for the existance of a resource based on its kind and ID
+        """
+        return await self._api.resource_exists(kind, resource_id)
+
     async def get_role(self, kind: str, role_id: str) -> json:
         """
         Gets a role based on its kind and ID

--- a/conjur_api/wrappers/http_wrapper.py
+++ b/conjur_api/wrappers/http_wrapper.py
@@ -37,6 +37,7 @@ class HttpVerb(Enum):
     PUT = 3
     DELETE = 4
     PATCH = 5
+    HEAD = 6
 
 
 # pylint: disable=too-many-locals,consider-using-f-string,too-many-arguments

--- a/tests/https/test_unit_client.py
+++ b/tests/https/test_unit_client.py
@@ -238,6 +238,17 @@ class ClientTest(IsolatedAsyncioTestCase):
         mock_invoke_endpoint.assert_called_once()
 
     @patch.object(Api, '_api_token', new_callable=PropertyMock)  
+    async def test_client_resource_exists_invokes_api(self, mock_api_token, mock_invoke_endpoint):
+        mock_api_token.return_value = 'test_token'
+        await self.client.resource_exists('role', 'dummy')
+
+        args, kwargs = mock_invoke_endpoint.call_args
+        self.assertEqual('test_token', kwargs.get('api_token'))
+        self.assertTrue(exists_in_args('role', args))
+        self.assertTrue(exists_in_args('dummy', args))
+        mock_invoke_endpoint.assert_called_once()
+
+    @patch.object(Api, '_api_token', new_callable=PropertyMock)  
     async def test_client_get_many_invokes_api(self, mock_api_token, mock_invoke_endpoint):
         mock_api_token.return_value = 'test_token'
         json_data = '{"test:variable:dummy-var":"myValue", \

--- a/tests/https/test_unit_http.py
+++ b/tests/https/test_unit_http.py
@@ -46,6 +46,7 @@ class HttpVerbTest(unittest.TestCase):
         self.assertTrue(HttpVerb.POST)
         self.assertTrue(HttpVerb.DELETE)
         self.assertTrue(HttpVerb.PATCH)
+        self.assertTrue(HttpVerb.HEAD)
 
 
 def create_ssl_verification_metadata(mode=SslVerificationMode.TRUST_STORE, cert_path=None):


### PR DESCRIPTION
### Desired Outcome

Add method to check whether a resource exists. Mimics what existed in the [Ruby API](https://github.com/cyberark/conjur-api-ruby/blob/41d99141a254b5e12374f7d792a721ff19ca4750/lib/conjur/acts_as_resource.rb#L62).

### Implemented Changes

- Added a `resource_exists` method to the `Client` and `Api` classes which invokes the `resources/{account}/{kind}/{identifier}` url on the Conjur server and checks the status code for 404 vs 200/403.

### Connected Issue/Story

Supports CyberArk internal issue: [ONYX-23083](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-23083)

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
