### PR TITLE
Add role memberships endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [8.0.0] - 2022-05-25
 
 ### Added
+- Add support for Role Memberships endpoint
+  [conjur-api-python#30](https://github.com/cyberark/conjur-api-python/pull/33)
 - Add support for Show Role endpoint
   [conjur-api-python#30](https://github.com/cyberark/conjur-api-python/pull/30)
 - Add support for Show Resource endpoint

--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ Check the existence of a resource based on its kind and ID. Returns a boolean.
 
 Gets a role based on its kind and ID. Role is json data that contains metadata about the role.
 
+#### `role_memberships(kind, role_id)`
+
+Gets a role's memberships based on its kind and ID. Returns a list of all roles recursively inherited by this role.
+
 #### `def list_permitted_roles(list_permitted_roles_data: ListPermittedRolesData)`
 
 Lists the roles which have the named permission on a resource.

--- a/conjur_api/client.py
+++ b/conjur_api/client.py
@@ -123,6 +123,12 @@ class Client:
         """
         return await self._api.get_role(kind, role_id)
 
+    async def role_memberships(self, kind: str, role_id: str, direct: bool = False) -> json:
+        """
+        Lists the memberships of a role
+        """
+        return await self._api.role_memberships(kind, role_id, direct)
+
     async def list_permitted_roles(self, list_permitted_roles_data: ListPermittedRolesData) -> dict:
         """
         Lists the roles which have the named permission on a resource.

--- a/conjur_api/http/api.py
+++ b/conjur_api/http/api.py
@@ -229,6 +229,30 @@ class Api:
         # ?tocpath=Developer%7CREST%C2%A0APIs%7C_____15
         return role
 
+    async def role_memberships(self, kind: str, resource_id: str, direct: bool) -> dict:
+        """
+        This method is used to fetch the memberships of a role
+        """
+        recursive_param = "memberships" if direct else "all"
+        params = {
+            'account': self._account,
+            'kind': kind,
+            'identifier': resource_id,
+            'membership': recursive_param
+        }
+        params.update(self._default_params)
+
+        response = await invoke_endpoint(HttpVerb.GET, ConjurEndpoint.ROLES_MEMBERSHIPS,
+                                         params,
+                                         api_token=await self.api_token,
+                                         ssl_verification_metadata=self.ssl_verification_data)
+
+        if direct:
+            memberships = map(lambda membership: membership['role'], response.json)
+            return list(memberships)
+
+        return response.json
+
     async def get_variable(self, variable_id: str, version: str = None) -> Optional[bytes]:
         """
         This method is used to fetch a secret's (aka "variable") value from

--- a/conjur_api/http/endpoints.py
+++ b/conjur_api/http/endpoints.py
@@ -34,5 +34,6 @@ class ConjurEndpoint(Enum):
     HOST_FACTORY_HOSTS = "{url}/host_factories/hosts"
     ROLE = "{url}/roles/{account}/{kind}/{identifier}"
     ROLES_MEMBERS_OF = "{url}/roles/{account}/{kind}/{identifier}?members"
+    ROLES_MEMBERSHIPS = "{url}/roles/{account}/{kind}/{identifier}?{membership}"
     RESOURCES_PERMITTED_ROLES =\
         "{url}/resources/{account}/{kind}/{identifier}?permitted_roles=true&privilege={privilege}"

--- a/tests/https/test_unit_client.py
+++ b/tests/https/test_unit_client.py
@@ -274,3 +274,27 @@ class ClientTest(IsolatedAsyncioTestCase):
         self.assertTrue(exists_in_args('policy', args))
         self.assertTrue(exists_in_args('dummy', args))
         mock_invoke_endpoint.assert_called_once()
+
+    @patch.object(Api, '_api_token', new_callable=PropertyMock)  
+    async def test_client_role_direct_memberships_invokes_api(self, mock_api_token, mock_invoke_endpoint):
+        mock_api_token.return_value = 'test_token'
+        await self.client.role_memberships('policy', 'dummy', True)
+
+        args, kwargs = mock_invoke_endpoint.call_args
+        self.assertEqual('test_token', kwargs.get('api_token'))
+        self.assertTrue(exists_in_args('policy', args))
+        self.assertTrue(exists_in_args('dummy', args))
+        self.assertTrue(exists_in_args('memberships', args))
+        mock_invoke_endpoint.assert_called_once()
+
+    @patch.object(Api, '_api_token', new_callable=PropertyMock)  
+    async def test_client_role_memberships_invokes_api(self, mock_api_token, mock_invoke_endpoint):
+        mock_api_token.return_value = 'test_token'
+        await self.client.role_memberships('policy', 'dummy')
+
+        args, kwargs = mock_invoke_endpoint.call_args
+        self.assertEqual('test_token', kwargs.get('api_token'))
+        self.assertTrue(exists_in_args('policy', args))
+        self.assertTrue(exists_in_args('dummy', args))
+        self.assertTrue(exists_in_args('all', args))
+        mock_invoke_endpoint.assert_called_once()

--- a/tests/https/test_unit_endpoints.py
+++ b/tests/https/test_unit_endpoints.py
@@ -59,3 +59,11 @@ class EndpointsTest(unittest.TestCase):
                                                              kind='rolekind',
                                                              identifier='roleid')
         self.assertEqual(endpoint, 'http://host/roles/myacct/rolekind/roleid')
+
+    def test_endpoint_has_correct_role_memberships_all_template_string(self):
+        endpoint = ConjurEndpoint.ROLES_MEMBERSHIPS.value.format(url='http://host',
+                                                             account='myacct',
+                                                             kind='rolekind',
+                                                             identifier='roleid',
+                                                             membership='all')
+        self.assertEqual(endpoint, 'http://host/roles/myacct/rolekind/roleid?all')


### PR DESCRIPTION
### Desired Outcome

Support the [Role Membership endpoint.](https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Developer/Conjur_API_List_Role_Membership.htm?TocPath=Developer%7CREST%C2%A0APIs%7C_____17) Default behavior should use the recursive membership method (?all), but also support direct membership only queries (?memberships).

### Implemented Changes

Added the following URL template and relevant API methods to return a JSON list of role memberships:
ROLES_MEMBERSHIPS = "{url}/roles/{account}/{kind}/{identifier}?{membership}"

### Connected Issue/Story

CyberArk internal issue link: [ONYX-24035](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-24035)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
