### PR TITLE
Create separate Role Exists function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [conjur-api-python#30](https://github.com/cyberark/conjur-api-python/pull/33)
 - Add support for Show Role endpoint
   [conjur-api-python#30](https://github.com/cyberark/conjur-api-python/pull/30)
+- Add `role_exists` method
+  [conjur-api-python#35](https://github.com/cyberark/conjur-api-python/pull/35)
 - Add support for Show Resource endpoint
   [conjur-api-python#31](https://github.com/cyberark/conjur-api-python/pull/31)
 - Add `resource_exists` method

--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ Check the existence of a resource based on its kind and ID. Returns a boolean.
 
 Gets a role based on its kind and ID. Role is json data that contains metadata about the role.
 
+#### `role_exists(kind, resource_id)`
+
+Check the existence of a role based on its kind and ID. Returns a boolean.
+
 #### `role_memberships(kind, role_id)`
 
 Gets a role's memberships based on its kind and ID. Returns a list of all roles recursively inherited by this role.

--- a/conjur_api/client.py
+++ b/conjur_api/client.py
@@ -123,6 +123,12 @@ class Client:
         """
         return await self._api.get_role(kind, role_id)
 
+    async def role_exists(self, kind: str, role_id: str) -> bool:
+        """
+        Check for the existance of a role based on its kind and ID
+        """
+        return await self._api.role_exists(kind, role_id)
+
     async def role_memberships(self, kind: str, role_id: str, direct: bool = False) -> json:
         """
         Lists the memberships of a role

--- a/conjur_api/http/api.py
+++ b/conjur_api/http/api.py
@@ -253,6 +253,33 @@ class Api:
 
         return response.json
 
+    async def role_exists(self, kind: str, resource_id: str) -> bool:
+        """
+        This method is used to check whether a specific role exists.
+        """
+        params = {
+            'account': self._account,
+            'kind': kind,
+            'identifier': resource_id
+        }
+        params.update(self._default_params)
+
+        try:
+            await invoke_endpoint(HttpVerb.HEAD, ConjurEndpoint.ROLE,
+                                  params,
+                                  api_token=await self.api_token,
+                                  ssl_verification_metadata=self.ssl_verification_data)
+        except HttpStatusError as err:
+            if err.status == 404:
+                return False
+
+            if err.status == 403:
+                return True
+
+            raise
+
+        return True
+
     async def get_variable(self, variable_id: str, version: str = None) -> Optional[bytes]:
         """
         This method is used to fetch a secret's (aka "variable") value from

--- a/tests/https/test_unit_client.py
+++ b/tests/https/test_unit_client.py
@@ -240,11 +240,11 @@ class ClientTest(IsolatedAsyncioTestCase):
     @patch.object(Api, '_api_token', new_callable=PropertyMock)  
     async def test_client_resource_exists_invokes_api(self, mock_api_token, mock_invoke_endpoint):
         mock_api_token.return_value = 'test_token'
-        await self.client.resource_exists('role', 'dummy')
+        await self.client.resource_exists('host', 'dummy')
 
         args, kwargs = mock_invoke_endpoint.call_args
         self.assertEqual('test_token', kwargs.get('api_token'))
-        self.assertTrue(exists_in_args('role', args))
+        self.assertTrue(exists_in_args('host', args))
         self.assertTrue(exists_in_args('dummy', args))
         mock_invoke_endpoint.assert_called_once()
 
@@ -273,6 +273,17 @@ class ClientTest(IsolatedAsyncioTestCase):
         self.assertEqual('test_token', kwargs.get('api_token'))
         self.assertTrue(exists_in_args('policy', args))
         self.assertTrue(exists_in_args('dummy', args))
+        mock_invoke_endpoint.assert_called_once()
+
+    @patch.object(Api, '_api_token', new_callable=PropertyMock)  
+    async def test_client_role_exists_invokes_api(self, mock_api_token, mock_invoke_endpoint):
+        mock_api_token.return_value = 'test_token'
+        await self.client.role_exists('user', 'someuser')
+
+        args, kwargs = mock_invoke_endpoint.call_args
+        self.assertEqual('test_token', kwargs.get('api_token'))
+        self.assertTrue(exists_in_args('user', args))
+        self.assertTrue(exists_in_args('someuser', args))
         mock_invoke_endpoint.assert_called_once()
 
     @patch.object(Api, '_api_token', new_callable=PropertyMock)  

--- a/tests/https/test_unit_http_ssl.py
+++ b/tests/https/test_unit_http_ssl.py
@@ -38,9 +38,10 @@ invalid_badssl_endpoints = [
 ]
 
 valid_badssl_endpoints = [
-    "https://ecc256.badssl.com",
-    "https://ecc384.badssl.com",
-    "https://extended-validation.badssl.com",
+    # These are temporarily broken, see https://github.com/chromium/badssl.com/issues/510 and #511
+    # "https://ecc256.badssl.com",
+    # "https://ecc384.badssl.com",
+    # "https://extended-validation.badssl.com",
     "https://rsa2048.badssl.com",
     "https://rsa4096.badssl.com",
     "https://rsa8192.badssl.com",


### PR DESCRIPTION
### Implemented Changes

Added a separate method, `role_exists`, which calls the API using a HEAD request and returns a boolean which
allows for a smaller network footprint than requiring the full GET request and also doesn't force the client to have knowledge of the status codes to understand whether the role exists.

This is the method we used in the [Ruby API](https://github.com/cyberark/conjur-api-ruby/blob/41d99141a254b5e12374f7d792a721ff19ca4750/lib/conjur/acts_as_role.rb#L57) and in the Resource methods in the Python API (#32).

### Connected Issue/Story

N/A

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
