### PR TITLE
OIDC fixes

### DIFF
--- a/conjur_api/client.py
+++ b/conjur_api/client.py
@@ -10,6 +10,7 @@ the Conjur server
 # Builtins
 import json
 import logging
+from datetime import datetime
 from typing import Optional
 
 from conjur_api.errors.errors import ResourceNotFoundException, MissingRequiredParameterException, HttpStatusError
@@ -91,7 +92,7 @@ class Client:
         """
         return await self._api.login()
 
-    async def authenticate(self) -> str:
+    async def authenticate(self) -> tuple[str, datetime]:
         """
         Authenticate to conjur using credentials provided to credentials provider
         @return: API token

--- a/conjur_api/client.py
+++ b/conjur_api/client.py
@@ -98,7 +98,7 @@ class Client:
         @return: API token
         """
         token, expiration = await self._api.authenticate()
-        return token, CredentialsData.expiration_datetime_to_str(expiration)
+        return token, CredentialsData.convert_expiration_datetime_to_str(expiration)
 
     async def whoami(self) -> dict:
         """

--- a/conjur_api/client.py
+++ b/conjur_api/client.py
@@ -18,7 +18,7 @@ from conjur_api.http.api import Api
 from conjur_api.interface.authentication_strategy_interface import AuthenticationStrategyInterface
 # Internals
 from conjur_api.models import SslVerificationMode, CreateHostData, CreateTokenData, ListMembersOfData, \
-    ListPermittedRolesData, ConjurConnectionInfo, Resource
+    ListPermittedRolesData, ConjurConnectionInfo, Resource, CredentialsData
 from conjur_api.utils.decorators import allow_sync_invocation
 
 LOGGING_FORMAT = '%(asctime)s %(levelname)s: %(message)s'
@@ -92,12 +92,13 @@ class Client:
         """
         return await self._api.login()
 
-    async def authenticate(self) -> tuple[str, datetime]:
+    async def authenticate(self) -> tuple[str, str]:
         """
         Authenticate to conjur using credentials provided to credentials provider
         @return: API token
         """
-        return await self._api.authenticate()
+        token, expiration = await self._api.authenticate()
+        return token, CredentialsData.expiration_datetime_to_str(expiration)
 
     async def whoami(self) -> dict:
         """

--- a/conjur_api/models/general/credentials_data.py
+++ b/conjur_api/models/general/credentials_data.py
@@ -8,6 +8,11 @@ This module represents the DTO that holds credential data
 
 
 # pylint: disable=too-few-public-methods
+from datetime import datetime
+
+EXPIRATION_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
 class CredentialsData:
     """
     Used for setting user input data to login to Conjur
@@ -40,3 +45,11 @@ class CredentialsData:
         """
         return self.machine == other.machine and self.username == other.username and self.password == \
                other.password and self.api_key == other.api_key
+
+    @staticmethod
+    def expiration_str_to_datetime(api_token_expiration: str) -> datetime:
+        return datetime.strptime(api_token_expiration, EXPIRATION_FORMAT)
+
+    @staticmethod
+    def expiration_datetime_to_str(api_token_expiration: datetime) -> str:
+        return api_token_expiration.strftime(EXPIRATION_FORMAT)

--- a/conjur_api/models/general/credentials_data.py
+++ b/conjur_api/models/general/credentials_data.py
@@ -8,6 +8,9 @@ This module represents the DTO that holds credential data
 
 
 # pylint: disable=too-few-public-methods
+from datetime import datetime
+
+
 class CredentialsData:
     """
     Used for setting user input data to login to Conjur
@@ -21,7 +24,7 @@ class CredentialsData:
         self.password = password
         self.api_key = api_key
         self.api_token = api_token
-        self.api_token_expiration = api_token_expiration
+        self.api_token_expiration = self._str_to_datetime(api_token_expiration)
 
     @classmethod
     def convert_dict_to_obj(cls, dic: dict):
@@ -40,3 +43,9 @@ class CredentialsData:
         """
         return self.machine == other.machine and self.username == other.username and self.password == \
                other.password and self.api_key == other.api_key
+
+    @staticmethod
+    def _str_to_datetime(api_token_expiration: str):
+        if api_token_expiration is None:
+            return None
+        return datetime.strptime(api_token_expiration, "%Y-%m-%d %H:%M:%S")

--- a/conjur_api/models/general/credentials_data.py
+++ b/conjur_api/models/general/credentials_data.py
@@ -8,9 +8,6 @@ This module represents the DTO that holds credential data
 
 
 # pylint: disable=too-few-public-methods
-from datetime import datetime
-
-
 class CredentialsData:
     """
     Used for setting user input data to login to Conjur
@@ -24,7 +21,7 @@ class CredentialsData:
         self.password = password
         self.api_key = api_key
         self.api_token = api_token
-        self.api_token_expiration = self._str_to_datetime(api_token_expiration)
+        self.api_token_expiration = api_token_expiration
 
     @classmethod
     def convert_dict_to_obj(cls, dic: dict):
@@ -43,9 +40,3 @@ class CredentialsData:
         """
         return self.machine == other.machine and self.username == other.username and self.password == \
                other.password and self.api_key == other.api_key
-
-    @staticmethod
-    def _str_to_datetime(api_token_expiration: str):
-        if api_token_expiration is None:
-            return None
-        return datetime.strptime(api_token_expiration, "%Y-%m-%d %H:%M:%S")

--- a/conjur_api/models/general/credentials_data.py
+++ b/conjur_api/models/general/credentials_data.py
@@ -46,10 +46,9 @@ class CredentialsData:
         return self.machine == other.machine and self.username == other.username and self.password == \
                other.password and self.api_key == other.api_key
 
-    @staticmethod
-    def expiration_str_to_datetime(api_token_expiration: str) -> datetime:
-        return datetime.strptime(api_token_expiration, EXPIRATION_FORMAT)
+    def api_token_expiration_datetime(self) -> datetime:
+        return datetime.strptime(self.api_token_expiration, EXPIRATION_FORMAT)
 
     @staticmethod
-    def expiration_datetime_to_str(api_token_expiration: datetime) -> str:
+    def convert_expiration_datetime_to_str(api_token_expiration: datetime) -> str:
         return api_token_expiration.strftime(EXPIRATION_FORMAT)

--- a/conjur_api/providers/__init__.py
+++ b/conjur_api/providers/__init__.py
@@ -6,3 +6,4 @@ This module holds all the providers of the SDK
 from conjur_api.providers.simple_credentials_provider import SimpleCredentialsProvider
 from conjur_api.providers.authn_authentication_strategy import AuthnAuthenticationStrategy
 from conjur_api.providers.ldap_authentication_strategy import LdapAuthenticationStrategy
+from conjur_api.providers.oidc_authentication_strategy import OidcAuthenticationStrategy

--- a/conjur_api/providers/authn_authentication_strategy.py
+++ b/conjur_api/providers/authn_authentication_strategy.py
@@ -59,7 +59,7 @@ class AuthnAuthenticationStrategy(AuthenticationStrategyInterface):
 
         # If the credential provider already has a valid API token, return it
         if self._is_authenticated(creds):
-            return str(creds.api_token), creds.expiration_str_to_datetime(creds.api_token_expiration)
+            return str(creds.api_token), creds.api_token_expiration_datetime
 
         await self._ensure_logged_in(connection_info, ssl_verification_data, creds)
         api_token = await self._send_authenticate_request(ssl_verification_data, connection_info, creds)
@@ -110,7 +110,7 @@ class AuthnAuthenticationStrategy(AuthenticationStrategyInterface):
     @staticmethod
     def _is_authenticated(creds) -> bool:
         if creds.api_token and creds.api_token_expiration:
-            return creds.expiration_str_to_datetime(creds.api_token_expiration) > datetime.now()
+            return creds.api_token_expiration_datetime > datetime.now()
         return False
 
     @staticmethod

--- a/conjur_api/providers/authn_authentication_strategy.py
+++ b/conjur_api/providers/authn_authentication_strategy.py
@@ -7,6 +7,7 @@ import base64
 import json
 import logging
 from datetime import datetime, timedelta
+from typing import cast
 
 from conjur_api.errors.errors import MissingRequiredParameterException
 from conjur_api.http.endpoints import ConjurEndpoint
@@ -21,7 +22,6 @@ from conjur_api.wrappers.http_wrapper import HttpVerb, invoke_endpoint
 DEFAULT_TOKEN_EXPIRATION = 8
 API_TOKEN_SAFETY_BUFFER = 3
 DEFAULT_API_TOKEN_DURATION = DEFAULT_TOKEN_EXPIRATION - API_TOKEN_SAFETY_BUFFER
-
 
 class AuthnAuthenticationStrategy(AuthenticationStrategyInterface):
     """
@@ -59,12 +59,16 @@ class AuthnAuthenticationStrategy(AuthenticationStrategyInterface):
 
         # If the credential provider already has a valid API token, return it
         if self._is_authenticated(creds):
-            return str(creds.api_token), creds.api_token_expiration
+            return str(creds.api_token), self._str_to_datetime(creds.api_token_expiration)
 
         await self._ensure_logged_in(connection_info, ssl_verification_data, creds)
         api_token = await self._send_authenticate_request(ssl_verification_data, connection_info, creds)
 
         return api_token, self._calculate_token_expiration(api_token)
+
+    @staticmethod
+    def _str_to_datetime(api_token_expiration: str):
+        return datetime.strptime(api_token_expiration, "%Y-%m-%d %H:%M:%S")
 
     def _retrieve_credential_data(self, url: str) -> CredentialsData:
         credential_location = self._credentials_provider.get_store_location()
@@ -110,7 +114,7 @@ class AuthnAuthenticationStrategy(AuthenticationStrategyInterface):
     @staticmethod
     def _is_authenticated(creds) -> bool:
         if creds.api_token and creds.api_token_expiration:
-            return creds.api_token_expiration > datetime.now()
+            return AuthnAuthenticationStrategy._str_to_datetime(creds.api_token_expiration) > datetime.now()
         return False
 
     @staticmethod

--- a/conjur_api/providers/authn_authentication_strategy.py
+++ b/conjur_api/providers/authn_authentication_strategy.py
@@ -7,7 +7,6 @@ import base64
 import json
 import logging
 from datetime import datetime, timedelta
-from typing import cast
 
 from conjur_api.errors.errors import MissingRequiredParameterException
 from conjur_api.http.endpoints import ConjurEndpoint
@@ -22,6 +21,7 @@ from conjur_api.wrappers.http_wrapper import HttpVerb, invoke_endpoint
 DEFAULT_TOKEN_EXPIRATION = 8
 API_TOKEN_SAFETY_BUFFER = 3
 DEFAULT_API_TOKEN_DURATION = DEFAULT_TOKEN_EXPIRATION - API_TOKEN_SAFETY_BUFFER
+
 
 class AuthnAuthenticationStrategy(AuthenticationStrategyInterface):
     """
@@ -59,16 +59,12 @@ class AuthnAuthenticationStrategy(AuthenticationStrategyInterface):
 
         # If the credential provider already has a valid API token, return it
         if self._is_authenticated(creds):
-            return str(creds.api_token), self._str_to_datetime(creds.api_token_expiration)
+            return str(creds.api_token), creds.expiration_str_to_datetime(creds.api_token_expiration)
 
         await self._ensure_logged_in(connection_info, ssl_verification_data, creds)
         api_token = await self._send_authenticate_request(ssl_verification_data, connection_info, creds)
 
         return api_token, self._calculate_token_expiration(api_token)
-
-    @staticmethod
-    def _str_to_datetime(api_token_expiration: str):
-        return datetime.strptime(api_token_expiration, "%Y-%m-%d %H:%M:%S")
 
     def _retrieve_credential_data(self, url: str) -> CredentialsData:
         credential_location = self._credentials_provider.get_store_location()
@@ -114,7 +110,7 @@ class AuthnAuthenticationStrategy(AuthenticationStrategyInterface):
     @staticmethod
     def _is_authenticated(creds) -> bool:
         if creds.api_token and creds.api_token_expiration:
-            return AuthnAuthenticationStrategy._str_to_datetime(creds.api_token_expiration) > datetime.now()
+            return creds.expiration_str_to_datetime(creds.api_token_expiration) > datetime.now()
         return False
 
     @staticmethod

--- a/conjur_api/providers/authn_authentication_strategy.py
+++ b/conjur_api/providers/authn_authentication_strategy.py
@@ -110,70 +110,7 @@ class AuthnAuthenticationStrategy(AuthenticationStrategyInterface):
     @staticmethod
     def _is_authenticated(creds) -> bool:
         if creds.api_token and creds.api_token_expiration:
-            return creds.api_token_expiration > datetime.now()
-        return False
-
-    @staticmethod
-    # pylint: disable=bare-except
-    def _calculate_token_expiration(api_token: str) -> datetime:
-        # Attempt to get the expiration from the token. If failing then the default expiration will be used
-        try:
-            # The token is in JSON format. Each field in the token is base64 encoded.
-            # So we decode the payload filed and then extract the expiration date from it
-            decoded_token_payload = base64.b64decode(json.loads(api_token)['payload'].encode('ascii'))
-            token_expiration = json.loads(decoded_token_payload)['exp']
-            return datetime.fromtimestamp(token_expiration) - timedelta(minutes=API_TOKEN_SAFETY_BUFFER)
-        except:
-            # If we can't extract the expiration from the token because we work with an older version
-            # of Conjur, then we use the default expiration
-            return datetime.now() + timedelta(minutes=DEFAULT_API_TOKEN_DURATION)
-
-    @staticmethod
-    def _is_authenticated(creds) -> bool:
-        if creds.api_token and creds.api_token_expiration:
-            return creds.api_token_expiration > datetime.now()
-        return False
-
-    @staticmethod
-    # pylint: disable=bare-except
-    def _calculate_token_expiration(api_token: str) -> datetime:
-        # Attempt to get the expiration from the token. If failing then the default expiration will be used
-        try:
-            # The token is in JSON format. Each field in the token is base64 encoded.
-            # So we decode the payload filed and then extract the expiration date from it
-            decoded_token_payload = base64.b64decode(json.loads(api_token)['payload'].encode('ascii'))
-            token_expiration = json.loads(decoded_token_payload)['exp']
-            return datetime.fromtimestamp(token_expiration) - timedelta(minutes=API_TOKEN_SAFETY_BUFFER)
-        except:
-            # If we can't extract the expiration from the token because we work with an older version
-            # of Conjur, then we use the default expiration
-            return datetime.now() + timedelta(minutes=DEFAULT_API_TOKEN_DURATION)
-
-    @staticmethod
-    def _is_authenticated(creds) -> bool:
-        if creds.api_token and creds.api_token_expiration:
-            return creds.api_token_expiration > datetime.now()
-        return False
-
-    @staticmethod
-    # pylint: disable=bare-except
-    def _calculate_token_expiration(api_token: str) -> datetime:
-        # Attempt to get the expiration from the token. If failing then the default expiration will be used
-        try:
-            # The token is in JSON format. Each field in the token is base64 encoded.
-            # So we decode the payload filed and then extract the expiration date from it
-            decoded_token_payload = base64.b64decode(json.loads(api_token)['payload'].encode('ascii'))
-            token_expiration = json.loads(decoded_token_payload)['exp']
-            return datetime.fromtimestamp(token_expiration) - timedelta(minutes=API_TOKEN_SAFETY_BUFFER)
-        except:
-            # If we can't extract the expiration from the token because we work with an older version
-            # of Conjur, then we use the default expiration
-            return datetime.now() + timedelta(minutes=DEFAULT_API_TOKEN_DURATION)
-
-    @staticmethod
-    def _is_authenticated(creds) -> bool:
-        if creds.api_token and creds.api_token_expiration:
-            return creds.api_token_expiration > datetime.now()
+            return datetime.strptime(creds.api_token_expiration, "%Y-%m-%d %H:%M:%S") > datetime.now()
         return False
 
     @staticmethod


### PR DESCRIPTION
### Desired Outcome

- init.py add OIDC
- Client::authenticate should declare to return expiration as well
- api_token_expiration is saved as string in CredentialData but compared with dateTime in _is_authenticated(creds)
- authn_authentication_strategy::_is_authenticated() and calculate_token_expiration() appears 4 times
- authn_authentication_strategy::authenticate() `cast` doesn’t work

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
