### PR TITLE
Fix logger to allow application consuming library to set logging level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Changed logging commands to logger
+
 ## [0.1.4] - 2025-03-26
 
 ### Fixed

--- a/conjur_api/client.py
+++ b/conjur_api/client.py
@@ -23,6 +23,7 @@ from conjur_api.utils.decorators import allow_sync_invocation
 LOGGING_FORMAT = '%(asctime)s %(levelname)s: %(message)s'
 LOGGING_FORMAT_WARNING = 'WARNING: %(message)s'
 
+logger = logging.getLogger(__name__)
 
 @allow_sync_invocation()
 # pylint: disable=too-many-public-methods
@@ -60,17 +61,17 @@ class Client:
         self.async_mode = async_mode
         if ssl_verification_mode == SslVerificationMode.INSECURE:
             # TODO remove this is a cli user facing
-            logging.debug("Warning: Running the command with '--insecure' "
+            logger.debug("Warning: Running the command with '--insecure' "
                           "makes your system vulnerable to security attacks")
 
-        logging.debug("Initializing configuration...")
+        logger.debug("Initializing configuration...")
 
         self.ssl_verification_mode = ssl_verification_mode
         self.connection_info = connection_info
         self.debug = debug
         self._api = self._create_api(http_debug, authn_strategy)
 
-        logging.debug("Client initialized")
+        logger.debug("Client initialized")
 
     @staticmethod
     def configure_logger(debug: bool):

--- a/conjur_api/http/api.py
+++ b/conjur_api/http/api.py
@@ -22,6 +22,7 @@ from conjur_api.models import Resource, ConjurConnectionInfo, ListPermittedRoles
 from conjur_api.wrappers.http_response import HttpResponse
 from conjur_api.wrappers.http_wrapper import HttpVerb, invoke_endpoint
 
+logger = logging.getLogger(__name__)
 
 # pylint: disable=unspecified-encoding,too-many-public-methods
 class Api:
@@ -83,11 +84,11 @@ class Api:
         @return: Conjur api_token
         """
         if not self._api_token or datetime.now() > self.api_token_expiration:
-            logging.debug("API token missing or expired. Fetching new one...")
+            logger.debug("API token missing or expired. Fetching new one...")
             self._api_token, self.api_token_expiration = await self.authenticate()
             return self._api_token
 
-        logging.debug("Using cached API token...")
+        logger.debug("Using cached API token...")
         return self._api_token
 
     async def login(self) -> str:
@@ -176,7 +177,7 @@ class Api:
                                              api_token=await self.api_token,
                                              ssl_verification_metadata=self.ssl_verification_data,
                                              proxy_params=self._connection_info.proxy_params)
-            logging.debug(str(response))
+            logger.debug(str(response))
         except HttpStatusError as err:
             if err.status == 404:
                 return False

--- a/conjur_api/http/ssl/ssl_context_factory.py
+++ b/conjur_api/http/ssl/ssl_context_factory.py
@@ -18,6 +18,7 @@ from conjur_api.errors.errors import UnknownOSError, MacCertificatesError
 from conjur_api.models.enums.os_types import OSTypes
 from conjur_api.utils.util_functions import get_current_os
 
+logger = logging.getLogger(__name__)
 
 # pylint: disable=too-few-public-methods
 def create_ssl_context(ssl_verification_metadata: SslVerificationMetadata) -> ssl.SSLContext:
@@ -29,7 +30,7 @@ def create_ssl_context(ssl_verification_metadata: SslVerificationMetadata) -> ss
     os_type = get_current_os()
 
     if ssl_verification_metadata.mode == SslVerificationMode.TRUST_STORE:
-        logging.debug("Creating SSLContext from OS TrustStore for '%s'", os_type.name)
+        logger.debug("Creating SSLContext from OS TrustStore for '%s'", os_type.name)
         ssl_context = _create_ssl_context(os_type)
     else:
         ssl_context = ssl.create_default_context(cafile=ssl_verification_metadata.ca_cert_path)
@@ -39,7 +40,7 @@ def create_ssl_context(ssl_verification_metadata: SslVerificationMetadata) -> ss
     # pylint: disable=no-member
     ssl_context.verify_flags |= ssl.OP_NO_TICKET
 
-    logging.debug("SSLContext created successfully")
+    logger.debug("SSLContext created successfully")
 
     return ssl_context
 
@@ -76,7 +77,7 @@ def _get_mac_ca_certs() -> str:
     Get Root CAs from Mac Keychain.
     @return: String containing trusted root CAs from the keychain.
     """
-    logging.debug("Get CA certs from Mac keychain")
+    logger.debug("Get CA certs from Mac keychain")
     try:
         get_ca_certs_process = subprocess.run(
             ["security", "find-certificate", "-a", "-p", "/System/Library/Keychains/SystemRootCertificates.keychain"],

--- a/conjur_api/providers/authn_authentication_strategy.py
+++ b/conjur_api/providers/authn_authentication_strategy.py
@@ -23,6 +23,7 @@ DEFAULT_TOKEN_EXPIRATION = 8
 API_TOKEN_SAFETY_BUFFER = 3
 DEFAULT_API_TOKEN_DURATION = DEFAULT_TOKEN_EXPIRATION - API_TOKEN_SAFETY_BUFFER
 
+logger = logging.getLogger(__name__)
 
 class AuthnAuthenticationStrategy(AuthenticationStrategyInterface):
     """
@@ -41,7 +42,7 @@ class AuthnAuthenticationStrategy(AuthenticationStrategyInterface):
         Login uses a username and password to fetch a long-lived conjur_api token
         """
 
-        logging.debug("Logging in to %s...", connection_info.conjur_url)
+        logger.debug("Logging in to %s...", connection_info.conjur_url)
         creds = self._retrieve_credential_data(connection_info.conjur_url)
 
         if not creds.password:
@@ -55,7 +56,7 @@ class AuthnAuthenticationStrategy(AuthenticationStrategyInterface):
         Authenticate uses the api_key (retrieved in `login()`) to fetch a short-lived conjur_api token that
         for a limited time will allow you to interact fully with the Conjur vault.
         """
-        logging.debug("Authenticating to %s...", connection_info.conjur_url)
+        logger.debug("Authenticating to %s...", connection_info.conjur_url)
         creds = self._retrieve_credential_data(connection_info.conjur_url)
 
         # If the credential provider already has a valid API token, return it
@@ -69,7 +70,7 @@ class AuthnAuthenticationStrategy(AuthenticationStrategyInterface):
 
     def _retrieve_credential_data(self, url: str) -> CredentialsData:
         credential_location = self._credentials_provider.get_store_location()
-        logging.debug("Retrieving credentials from the '%s'...", credential_location)
+        logger.debug("Retrieving credentials from the '%s'...", credential_location)
 
         return self._credentials_provider.load(url)
 

--- a/conjur_api/providers/jwt_authentication_strategy.py
+++ b/conjur_api/providers/jwt_authentication_strategy.py
@@ -25,6 +25,8 @@ DEFAULT_TOKEN_EXPIRATION = 8
 API_TOKEN_SAFETY_BUFFER = 3
 DEFAULT_API_TOKEN_DURATION = DEFAULT_TOKEN_EXPIRATION - API_TOKEN_SAFETY_BUFFER
 
+logger = logging.getLogger(__name__)
+
 class JWTAuthenticationStrategy(AuthenticationStrategyInterface):
     """
     JWTAuthenticationStrategy
@@ -49,7 +51,7 @@ class JWTAuthenticationStrategy(AuthenticationStrategyInterface):
         Authenticate method makes a POST request to the authentication endpoint,
         retrieves a token, and calculates the token expiration.
         """
-        logging.debug("Authenticating to %s...", connection_info.conjur_url)
+        logger.debug("Authenticating to %s...", connection_info.conjur_url)
 
         api_token = await self._send_authenticate_request(ssl_verification_data, connection_info)
 

--- a/conjur_api/utils/decorators.py
+++ b/conjur_api/utils/decorators.py
@@ -8,6 +8,7 @@ import inspect
 import asyncio
 from conjur_api.errors.errors import SyncInvocationInsideEventLoopError
 
+logger = logging.getLogger(__name__)
 
 def allow_sync_invocation():
     """
@@ -23,7 +24,7 @@ def allow_sync_invocation():
                 return func(self, *args)
             loop = _get_event_loop()
             if loop is not None and loop.is_running():
-                logging.error(
+                logger.error(
                     "Failed to run conjur_api %s function in sync mode "
                     "because code is running inside event loop", func.__name__)
                 raise SyncInvocationInsideEventLoopError()
@@ -45,5 +46,5 @@ def _get_event_loop():
     except RuntimeError:  # No loop exist
         return None
     except Exception as err:
-        logging.error("Couldn't get event loop for unknown reason. details: %s", err)
+        logger.error("Couldn't get event loop for unknown reason. details: %s", err)
         raise


### PR DESCRIPTION
### Desired Outcome

Today there is no way to import the library and setup logging specifically for this library.
This addresses this problem.

### Implemented Changes

In files where we where doing logging.debug it was replaced with logger.debug and a logger was imported using the library as the name (using __name__)

### Connected Issue/Story

Resolves #54 

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
