### PR TITLE
Bump cryptography to >=48.0 to fix CVE-2026-34180

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Security
+- Bump `cryptography` constraint to `~=48.0` to allow `cryptography>=48.0.1`
+  (CVE-2026-34180 / SNYK-PYTHON-CRYPTOGRAPHY-17344551), unblocking downstream
+  consumers capped by the previous `~=46.0.5` pin.
+
 ## [0.1.10] - 2026-03-24
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Security
-- Bump `cryptography` constraint to `~=48.0` to allow `cryptography>=48.0.1`
-  (CVE-2026-34180 / SNYK-PYTHON-CRYPTOGRAPHY-17344551), unblocking downstream
-  consumers capped by the previous `~=46.0.5` pin.
+- Relax `cryptography` constraint to `>=48.0.1` (CVE-2026-34180 /
+  SNYK-PYTHON-CRYPTOGRAPHY-17344551), unblocking downstream consumers capped
+  by the previous `~=46.0.5` pin. No upper bound — `cryptography` is a
+  transitive dependency and is not imported directly.
 
 ## [0.1.10] - 2026-03-24
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 pytest>=9.0.2
 pytest-cov>=7.1.0
 pylint>=4.0.5
-cryptography~=48.0
+cryptography>=48.0.1
 keyring>=25.7.0
 pyopenssl>=26.0.0
 PyInstaller>=6.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 pytest>=9.0.2
 pytest-cov>=7.1.0
 pylint>=4.0.5
-cryptography~=46.0.5
+cryptography~=48.0
 keyring>=25.7.0
 pyopenssl>=26.0.0
 PyInstaller>=6.19.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ zip_safe = True
 include_package_data = False
 
 install_requires =
-  cryptography~=48.0
+  cryptography>=48.0.1
   keyring>=25.7.0
   aiohttp>=3.13.3
   asynctest >= 0.13.0; python_version<"3.8"

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ zip_safe = True
 include_package_data = False
 
 install_requires =
-  cryptography~=46.0.5
+  cryptography~=48.0
   keyring>=25.7.0
   aiohttp>=3.13.3
   asynctest >= 0.13.0; python_version<"3.8"


### PR DESCRIPTION
## What
Bump the `cryptography` constraint from `~=46.0.5` to `~=48.0` in `setup.cfg` and `requirements.txt`.

## Why
`cryptography~=46.0.5` caps the dependency at `>=46.0.5,<47`, which blocks downstream consumers from resolving `cryptography>=48.0.1` — the fix for **CVE-2026-34180** (SNYK-PYTHON-CRYPTOGRAPHY-17344551, out-of-bounds read in the ASN.1 decoder). Any project depending on `conjur-api` inherits the vulnerable ceiling and cannot remediate.

`cryptography` is a transitive dependency here — it is **not imported directly** anywhere in `conjur_api` — so widening the constraint has no API-surface impact.

## Testing
- `cryptography~=48.0` resolves cleanly (48.0.1) alongside the other pinned deps (keyring, aiohttp, pyopenssl, urllib3).
- Ran the unit suite on both `cryptography 46.0.7` (baseline) and `48.0.1`: **identical results** — the same pre-existing platform/network-dependent failures (OS trust-store string, live badssl.com endpoints) appear in both; the crypto bump introduces **zero new failures**.

## Changelog
Added a `### Security` entry under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)